### PR TITLE
Remove non-existent install options from local-installation.md

### DIFF
--- a/docs/local-installation.md
+++ b/docs/local-installation.md
@@ -163,12 +163,6 @@ brew install socket
 # Using npm (if you have Node.js):
 npm install -g @socketsecurity/cli
 
-# Manual installation (Linux):
-curl -sSL https://socket.dev/install.sh | sh
-
-# Manual installation (macOS):
-curl -sSL https://socket.dev/install.sh | sh
-
 # Verify installation
 socket --version
 ```

--- a/docs/local-installation.md
+++ b/docs/local-installation.md
@@ -158,7 +158,7 @@ Socket Basics orchestrates multiple security tools. Install the ones you need:
 
 ```bash
 # Using npm (if you have Node.js):
-npm install -g @socketsecurity/cli
+npm install -g socket
 
 # Verify installation
 socket --version

--- a/docs/local-installation.md
+++ b/docs/local-installation.md
@@ -157,9 +157,6 @@ Socket Basics orchestrates multiple security tools. Install the ones you need:
 **Installation:**
 
 ```bash
-# macOS/Linux with Homebrew:
-brew install socket
-
 # Using npm (if you have Node.js):
 npm install -g @socketsecurity/cli
 


### PR DESCRIPTION
Neither of these are valid:

# Manual installation (Linux):
curl -sSL https://socket.dev/install.sh | sh

# Manual installation (macOS):
curl -sSL https://socket.dev/install.sh | sh