### PR TITLE
Fix: Empty CLI string defaults no longer override env/API config

### DIFF
--- a/socket_basics/core/config.py
+++ b/socket_basics/core/config.py
@@ -1275,7 +1275,9 @@ def create_config_from_args(args) -> Config:
                                     for disabled_param in param['disables']:
                                         config_dict[disabled_param] = False
                                         
-                            elif param.get('type') != 'bool':
+                            elif param.get('type') != 'bool' and arg_value:
+                                # Only override config for non-bool types if CLI arg has a value
+                                # This prevents empty string defaults from wiping out env/API config
                                 config_dict[param_name] = arg_value
     except Exception as e:
         logging.getLogger(__name__).warning("Warning: Error processing dynamic CLI args: %s", e)


### PR DESCRIPTION
## Summary
- Fixes a bug where CLI argument defaults (empty strings) were incorrectly overwriting values loaded from environment variables and the Socket Basics API dashboard config
- Changes the condition from `if arg_value is not None` to `if arg_value` for non-bool types

## Problem
When CLI arguments with empty string defaults (like `--dockerfiles`) are not explicitly provided by the user, they were overwriting non-empty values from:
1. Environment variables (e.g., `INPUT_DOCKERFILES` set via GitHub Actions workflow)
2. Socket Basics API config (dashboard settings)

This caused Dockerfile scanning to fail even when correctly configured in the dashboard with `dockerfiles: "Dockerfile"`, because the CLI default of `""` would wipe out that value.

## Root Cause
```python
# Before: empty string passes this check
if arg_value is not None:
    config_dict[param_name] = arg_value  # Overwrites with ""
```

## Fix
```python
# After: empty string is falsy, won't override
if arg_value:
    config_dict[param_name] = arg_value
```

## Test plan
- [x] Verified dashboard API returns correct `dockerfiles: "Dockerfile"` value
- [ ] Test Dockerfile scanning with dashboard config only (no workflow input)
- [ ] Test Dockerfile scanning with explicit workflow input
- [ ] Test that explicit CLI args still override when provided