### PR TITLE
feat: add SKIP_SOCKET_REACH and SKIP_SOCKET_SUBMISSION env vars for Node.js Socket CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ All configuration can be managed through:
 
 See [Configuration Documentation](docs/configuration.md) for details on all available options.
 
+#### Integration Environment Variables
+
+Socket Basics supports special environment variables for integration with other tools:
+
+- **`SKIP_SOCKET_REACH=1`** — Skip Socket Tier 1 reachability analysis. This allows external tools (like the Node.js Socket CLI) to skip redundant reachability scans when the analysis will be performed separately or is not needed for a particular workflow.
+
+- **`SKIP_SOCKET_SUBMISSION=1`** — Skip submission to Socket API while still generating `.socket.facts.json`. This allows external tools (like the Node.js Socket CLI) to collect the facts file and submit it along with other data in a unified API call. When this is set, Socket Basics will complete all scanning and generate the facts file, but will not make the API submission call.
+
 ## 🎯 What Socket Basics Does
 
 1. **Scans** your codebase using multiple security tools in parallel

--- a/socket_basics/core/connector/socket_tier1/scanner.py
+++ b/socket_basics/core/connector/socket_tier1/scanner.py
@@ -100,6 +100,13 @@ class SocketTier1Scanner(BaseConnector):
         return shlex.split(raw)
 
     def scan(self) -> Dict[str, Any]:
+        # Check if Socket Tier 1 reachability scan should be skipped (for Node.js Socket CLI integration).
+        # When SKIP_SOCKET_REACH=1, Socket Basics skips the reachability analysis. This allows the Node.js
+        # Socket CLI to skip redundant scans when reachability analysis will be performed separately.
+        if os.getenv('SKIP_SOCKET_REACH') == '1':
+            logger.info("Skipping Socket Tier 1 reachability scan (SKIP_SOCKET_REACH=1)")
+            return {}
+
         # Verify auth
         auth_env = self._get_auth_env()
         if not auth_env.get('SOCKET_ORG') or not auth_env.get('SOCKET_SECURITY_API_KEY'):

--- a/socket_basics/socket_basics.py
+++ b/socket_basics/socket_basics.py
@@ -199,14 +199,25 @@ class SecurityScanner:
 
     def submit_socket_facts(self, socket_facts_path: Path, results: Dict[str, Any]) -> Dict[str, Any]:
         """Submit the socket facts file to Socket API and return full scan results.
-        
+
         Args:
             socket_facts_path: Path to the .socket.facts.json file
             results: Current scan results dict to update with full scan info
-            
+
         Returns:
             Updated results dict with full scan information (id, html_url)
         """
+        # Check if Socket submission should be skipped (for Node.js Socket CLI integration).
+        # When SKIP_SOCKET_SUBMISSION=1, socket-basics generates the .socket.facts.json
+        # file but does not submit it to the Socket API. This allows the Node.js Socket CLI to
+        # collect the facts and submit them in a unified API call along with manifest data.
+        if os.getenv('SKIP_SOCKET_SUBMISSION') == '1':
+            logger.info("Skipping Socket API submission (SKIP_SOCKET_SUBMISSION=1)")
+            logger.debug(f"Socket facts file will be available at: {socket_facts_path}")
+            # Include the facts file path in results for downstream tools.
+            results['socket_facts_path'] = str(socket_facts_path)
+            return results
+
         try:
             # Check if socket facts file is empty or has no components
             if not socket_facts_path.exists():


### PR DESCRIPTION
## Summary

Add support for `SKIP_SOCKET_REACH` and `SKIP_SOCKET_SUBMISSION` env vars to enable Node.js Socket CLI integration. This allows the Node.js Socket CLI to run socket-basics in the background, collect the `.socket.facts.json` file, and submit it along with manifest data in a unified API call.

## Motivation

The npm Socket CLI wants to integrate socket-basics. To achieve this:

1. **Background Execution**: socket-basics runs in parallel with manifest collection
2. **Unified Submission**: Single API call with all findings (manifests + socket-basics facts)
3. **Consolidated View**: One scan ID on the dashboard showing all security findings

Without this change, socket-basics would submit independently, creating fragmented results.

## Changes

### Code Changes

- **`socket_basics/socket_basics.py`**: Added environment variable check in `submit_socket_facts()`
  - When `SKIP_SOCKET_REACH=1`, skips tier 1 reachability scans (coana)
  - When `SKIP_SOCKET_SUBMISSION=1`, skips Socket API submission
  - Still generates `.socket.facts.json` with all findings
  - Returns `socket_facts_path` in results for downstream tools

### Documentation Changes

- **`README.md`**: Added "Integration Environment Variables" section
  - Documents `SKIP_SOCKET_REACH` and `SKIP_SOCKET_SUBMISSION`
  - Explains use case for external tool integration

## How It Works

```bash
# Normal operation - socket-basics submits to API
docker run socketdev/socket-basics:latest

# CLI integration mode - socket-basics generates facts but doesn't submit
  docker run \
    -e SKIP_SOCKET_SUBMISSION=1 \
    -e SKIP_SOCKET_REACH=1 \
    socketdev/socket-basics:latest
# CLI then collects .socket.facts.json and submits with other data
```
