### PR TITLE
Remove CODEOWNERS entry for @SocketDev/eng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SocketDev/eng
+


### PR DESCRIPTION
This single line pings all the engineers on every github pull request. its a really annoying github feature.

this fixes all the pings on github notifications.