### PR TITLE
Update CODEOWNERS to reference GitHub Enterprise team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-
+* @SocketDev/ent:customer-engineering


### PR DESCRIPTION
Now that we have a more narrowly-scoped CE team on GitHub Enterprise, we should map that to the `CODEOWNERS` file.