### PR TITLE
Fix `CODEOWNERS` syntax 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SocketDev/ent:customer-engineering
+* @SocketDev/customer-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SocketDev/ent:customer-engineering
+* @/ent:customer-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SocketDev/customer-engineering
+* @SocketDev/ent:customer-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @/ent:customer-engineering
+* @SocketDev/customer-success


### PR DESCRIPTION
According to https://docs.github.com/en/enterprise-cloud@latest/admin/concepts/enterprise-fundamentals/teams-in-an-enterprise#what-are-teams, GitHub Enterprise Teams (such as `ent:customer-engineering`) do not currently support use in `CODEOWNERS` files, so the previous update did not properly take effect. Instead, we will revert to using a traditional GitHub Organization-style team, and can leverage the `customer-success` we already have to do so easily.