### PR TITLE
Final `CODEOWNERS` update with new team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SocketDev/customer-success
+* @SocketDev/customer-engineering


### PR DESCRIPTION
Since we [cannot use](https://github.com/SocketDev/socket-basics/pull/35) the new Enterprise customer eng team for `CODEOWNERS`, we have instead renamed the previous Organization team from `customer-success` to `customer-engineering` to reflect the current team structure. 