### PR TITLE
Bump Trivy from v0.67.2 to v0.69.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
 RUN npm install -g socket
 
 # Install Trivy
-ARG TRIVY_VERSION=v0.67.2
+ARG TRIVY_VERSION=v0.69.2
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
 
 # Install Trufflehog


### PR DESCRIPTION
## Summary

- Trivy v0.67.2 GitHub Release was deleted as part of a [security incident on March 1](https://github.com/aquasecurity/trivy/discussions/10265). An attacker wiped all releases from v0.27.0 through v0.69.1.
- The install script finds the git tag but the binary download 404s, breaking the Docker build.
- v0.69.2 is the only version with restored release assets.

## Steps to reproduce

```bash
# Install script finds the tag but fails to download the deleted binary
mkdir -p /tmp/trivy-test
curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
  | sh -s -- -b /tmp/trivy-test "v0.67.2"
# Output:
# aquasecurity/trivy info checking GitHub for tag 'v0.67.2'
# aquasecurity/trivy info found version: 0.67.2 for v0.67.2/Linux/64bit
# (exits with code 1 — release assets are 404)
```

Confirmed v0.69.2 installs successfully:
```bash
curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
  | sh -s -- -b /tmp/trivy-test "v0.69.2"
# aquasecurity/trivy info checking GitHub for tag 'v0.69.2'
# aquasecurity/trivy info found version: 0.69.2 for v0.69.2/macOS/ARM64
# aquasecurity/trivy info installed /tmp/trivy-test/trivy
# (exits with code 0)
```

## Test plan

- [ ] Verify Docker build completes successfully with v0.69.2
- [ ] Verify `trivy --version` outputs 0.69.2 inside the container