### PR TITLE
Pin `opengrep` version, add Docker smoketest

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,6 +31,6 @@ jobs:
       DOCKER_BUILDKIT: "1"
       SMOKE_TEST_BUILD_PROGRESS: plain
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 🐳 smoke test
         run: bash ./scripts/smoke-test-docker.sh --image-tag socket-basics:smoke-test

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,36 @@
+name: smoke-test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'scripts/smoke-test-docker.sh'
+      - '.github/workflows/smoke-test.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'scripts/smoke-test-docker.sh'
+      - '.github/workflows/smoke-test.yml'
+  schedule:
+    - cron: '0 */12 * * *' # every 12 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DOCKER_BUILDKIT: "1"
+      SMOKE_TEST_BUILD_PROGRESS: plain
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🐳 smoke test
+        run: bash ./scripts/smoke-test-docker.sh --image-tag socket-basics:smoke-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,12 @@ ARG TRIVY_VERSION=v0.69.2
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
 
 # Install Trufflehog
-ARG TRUFFLEHOG_VERSION=v3.93.3
+ARG TRUFFLEHOG_VERSION=v3.93.6
 RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin "${TRUFFLEHOG_VERSION}"
 
 # Install OpenGrep (connector/runtime dependency)
-RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
+ARG OPENGREP_VERSION=v1.16.2
+RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash -s -- -v "${OPENGREP_VERSION}"
 
 # Copy the specific files needed for the project
 COPY socket_basics /socket-basics/socket_basics

--- a/README.md
+++ b/README.md
@@ -154,12 +154,13 @@ docker run --rm -v "$PWD:/workspace" socketdev/socket-basics:1.1.2 \
   --console-tabular-enabled
 ```
 
-Tip: If you need specific Trivy or TruffleHog versions, you can override them at build time:
+Tip: If you need specific Trivy, TruffleHog, or OpenGrep versions, you can override them at build time:
 
 ```bash
 docker build \
-  --build-arg TRIVY_VERSION=v0.67.2 \
-  --build-arg TRUFFLEHOG_VERSION=v3.93.3 \
+  --build-arg TRIVY_VERSION=v0.69.2 \
+  --build-arg TRUFFLEHOG_VERSION=v3.93.6 \
+  --build-arg OPENGREP_VERSION=v1.16.2 \
   -t socketdev/socket-basics:1.1.2 .
 ```
 

--- a/app_tests/Dockerfile
+++ b/app_tests/Dockerfile
@@ -23,10 +23,16 @@ RUN apt-get update && \
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh  | sh -s -- -b /usr/local/bin v2.21.4
 
 # Install Trivy
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.18.3
+ARG TRIVY_VERSION=v0.69.2
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
 
 # Install Trufflehog
-RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+ARG TRUFFLEHOG_VERSION=v3.93.6
+RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin "${TRUFFLEHOG_VERSION}"
+
+# Install OpenGrep (connector/runtime dependency)
+ARG OPENGREP_VERSION=v1.16.2
+RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash -s -- -v "${OPENGREP_VERSION}"
 
 # Install Bandit using uv as a tool
 RUN uv tool install bandit
@@ -50,7 +56,7 @@ COPY pyproject.toml uv.lock /scripts/
 # Install Python dependencies using uv
 WORKDIR /scripts
 RUN uv sync --frozen && uv pip install light-s3-client
-ENV PATH="/scripts/.venv/bin:$PATH"
+ENV PATH="/scripts/.venv/bin:/root/.opengrep/cli/latest:$PATH"
 
 # Define entrypoint
 ENTRYPOINT ["/socket-security-tools/entrypoint.sh"]

--- a/docs/local-install-docker.md
+++ b/docs/local-install-docker.md
@@ -65,6 +65,20 @@ docker build -t myorg/security-scanner:1.1.2 .
 docker build --platform linux/amd64 -t socket-basics:1.1.2 .
 ```
 
+### Build with Custom Tool Versions
+
+The image pins Trivy, TruffleHog, and OpenGrep to specific versions. You can override any of them at build time:
+
+```bash
+docker build \
+  --build-arg TRIVY_VERSION=v0.69.2 \
+  --build-arg TRUFFLEHOG_VERSION=v3.93.6 \
+  --build-arg OPENGREP_VERSION=v1.16.2 \
+  -t socket-basics:1.1.2 .
+```
+
+Omit any `--build-arg` to use the default version for that tool. For the app tests image, build from the `app_tests` directory and use the same build args.
+
 ### Verify Installation
 
 ```bash
@@ -75,6 +89,22 @@ docker run --rm socket-basics:1.1.2 trivy --version
 docker run --rm socket-basics:1.1.2 opengrep --version
 docker run --rm socket-basics:1.1.2 trufflehog --version
 ```
+
+### Smoke Test
+
+To test that the pinned tool versions still work (upstream installer scripts can break), run:
+
+```bash
+./scripts/smoke-test-docker-image.sh
+```
+
+With `--app-tests` to also test the app_tests image (requires full build context):
+
+```bash
+./scripts/smoke-test-docker-image.sh --app-tests
+```
+
+This builds the image(s) and verifies Trivy, TruffleHog, and OpenGrep are installed and executable. A GitHub Action runs this on Dockerfile changes and daily.
 
 ## Running Scans
 

--- a/docs/local-install-docker.md
+++ b/docs/local-install-docker.md
@@ -92,16 +92,22 @@ docker run --rm socket-basics:1.1.2 trufflehog --version
 
 ### Smoke Test
 
-To test that the pinned tool versions still work (upstream installer scripts can break), run:
+To test that the pinned tool versions still work, run:
 
 ```bash
-./scripts/smoke-test-docker-image.sh
+./scripts/smoke-test-docker.sh
+```
+
+Add `--build-progress plain` when you want verbose Docker build logs:
+
+```bash
+./scripts/smoke-test-docker.sh --build-progress plain
 ```
 
 With `--app-tests` to also test the app_tests image (requires full build context):
 
 ```bash
-./scripts/smoke-test-docker-image.sh --app-tests
+./scripts/smoke-test-docker.sh --app-tests
 ```
 
 This builds the image(s) and verifies Trivy, TruffleHog, and OpenGrep are installed and executable. A GitHub Action runs this on Dockerfile changes and daily.

--- a/scripts/smoke-test-docker.sh
+++ b/scripts/smoke-test-docker.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-socket-basics:smoke-test}"
+APP_TESTS_IMAGE_TAG="${APP_TESTS_IMAGE_TAG:-socket-basics-app-tests:smoke-test}"
+RUN_APP_TESTS=false
+BUILD_PROGRESS="${SMOKE_TEST_BUILD_PROGRESS:-}"
+
+MAIN_TOOLS=(
+  "socket-basics -h"
+  "command -v socket"
+  "trivy --version"
+  "trufflehog --version"
+  "opengrep --version"
+)
+
+APP_TESTS_TOOLS=(
+  "trivy --version"
+  "trufflehog --version"
+  "opengrep --version"
+  "command -v socket"
+)
+
+usage() {
+  echo "Usage: $0 [--image-tag TAG] [--app-tests] [--build-progress MODE]"
+  echo "  --build-progress: auto|plain|tty (default: auto locally, plain in CI)"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --image-tag)
+      [[ $# -lt 2 ]] && { echo "Error: --image-tag requires a value"; exit 1; }
+      IMAGE_TAG="$2"; shift 2
+      ;;
+    --app-tests) RUN_APP_TESTS=true; shift ;;
+    --build-progress)
+      [[ $# -lt 2 ]] && { echo "Error: --build-progress requires a value"; exit 1; }
+      BUILD_PROGRESS="$2"; shift 2
+      ;;
+    *) echo "Error: unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$BUILD_PROGRESS" ]]; then
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    BUILD_PROGRESS="plain"
+  else
+    BUILD_PROGRESS="auto"
+  fi
+fi
+
+case "$BUILD_PROGRESS" in
+  auto|plain|tty) ;;
+  *) echo "Error: invalid --build-progress '$BUILD_PROGRESS'"; exit 1 ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: Docker CLI is not installed or not in PATH."
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker daemon is not reachable."
+  exit 1
+fi
+
+build_args_for_tag() {
+  local tag="$1"
+  BUILD_ARGS=(--progress "$BUILD_PROGRESS" -t "$tag")
+  [[ -n "${TRIVY_VERSION:-}" ]] && BUILD_ARGS+=(--build-arg "TRIVY_VERSION=$TRIVY_VERSION")
+  [[ -n "${TRUFFLEHOG_VERSION:-}" ]] && BUILD_ARGS+=(--build-arg "TRUFFLEHOG_VERSION=$TRUFFLEHOG_VERSION")
+  [[ -n "${OPENGREP_VERSION:-}" ]] && BUILD_ARGS+=(--build-arg "OPENGREP_VERSION=$OPENGREP_VERSION")
+  return 0
+}
+
+run_checks() {
+  local tag="$1"
+  shift
+  local checks=("$@")
+  for cmd in "${checks[@]}"; do
+    if docker run --rm --entrypoint /bin/sh "$tag" -c "$cmd" > /dev/null 2>&1; then
+      echo "  OK: $cmd"
+    else
+      echo "  FAIL: $cmd"
+      docker run --rm --entrypoint /bin/sh "$tag" -c "$cmd" 2>&1 || true
+      return 1
+    fi
+  done
+}
+
+cd "$REPO_ROOT"
+
+echo "==> Build main image"
+echo "Image: $IMAGE_TAG"
+echo "Docker build progress mode: $BUILD_PROGRESS"
+build_args_for_tag "$IMAGE_TAG"
+main_build_start="$(date +%s)"
+docker build "${BUILD_ARGS[@]}" .
+main_build_end="$(date +%s)"
+echo "Main image build completed in $((main_build_end - main_build_start))s"
+
+echo "==> Verify tools in main image"
+run_checks "$IMAGE_TAG" "${MAIN_TOOLS[@]}"
+
+if $RUN_APP_TESTS; then
+  echo "==> Build app_tests image"
+  echo "Image: $APP_TESTS_IMAGE_TAG"
+  build_args_for_tag "$APP_TESTS_IMAGE_TAG"
+  app_build_start="$(date +%s)"
+  docker build -f app_tests/Dockerfile "${BUILD_ARGS[@]}" .
+  app_build_end="$(date +%s)"
+  echo "app_tests image build completed in $((app_build_end - app_build_start))s"
+
+  echo "==> Verify tools in app_tests image"
+  run_checks "$APP_TESTS_IMAGE_TAG" "${APP_TESTS_TOOLS[@]}"
+fi
+
+echo "==> Smoke test passed"


### PR DESCRIPTION
## Changes
* Pins `opengrep` to a tagged version, similar to what we've already done with Trivy and Trufflehog
* Adds both a local script and GitHub workflow for smoke-testing changes made to the Dockerfile

This should help us catch upstream OSS tooling issues earlier, as the workflow will run on a cron schedule as well as whenever changes are made to the pinned image versions or Docker building process.