### PR TITLE
Add floating major version tag workflow

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -1,0 +1,34 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Update floating major version tag
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+
+          # Extract major version (e.g., "1" from "1.1.3")
+          MAJOR="v${VERSION%%.*}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Delete existing major version tag if it exists
+          git tag -d "$MAJOR" 2>/dev/null || true
+          git push origin ":refs/tags/$MAJOR" 2>/dev/null || true
+
+          # Create new tag pointing to the release commit
+          git tag "$MAJOR"
+          git push origin "$MAJOR"
+
+          echo "Updated $MAJOR tag to point to $VERSION"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs on each release and updates a floating major version tag (e.g., `v1`)
- Lets consumers reference `SocketDev/socket-basics@v1` instead of pinning to a specific version like `@1.1.3`
- Follows the same pattern used by `actions/checkout` (`@v4`), `actions/setup-node` (`@v4`), etc.

## How it works
When a release is published (e.g., `1.1.4`), the workflow:
1. Extracts the major version (`v1`)
2. Deletes the existing `v1` tag if present
3. Re-creates `v1` pointing to the release commit

## Test plan
- [ ] Publish a release and verify the `v1` tag is created/updated
- [ ] Confirm `SocketDev/socket-basics@v1` resolves to the latest release