### PR TITLE
fix(ci): add conventional commit prefixes to Dependabot config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!-- PR TITLE: use Conventional Commits format — the commit-lint CI check enforces this.
+     type(scope): Description    →    feat(docker): Add versioned Node stage
+     Valid types: feat · fix · docs · chore · ci · refactor · test · perf · revert
+     Breaking change: add ! after type  →  feat!: Switch to pre-built images -->
+
 ## Summary
 
 <!-- What does this PR do? Why? -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    commit-message:
+      prefix: "chore"
+      include: "scope"   # → chore(deps): bump trivy from 0.69.2 to 0.69.3
 
   # app_tests Dockerfile — same as above, plus golang and securego/gosec.
   - package-ecosystem: "docker"
@@ -21,6 +24,9 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   # GitHub Actions — tracks all uses: ... action versions.
   - package-ecosystem: "github-actions"
@@ -30,3 +36,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"   # → ci(deps): bump actions/checkout from v3 to v4


### PR DESCRIPTION
## Summary

Dependabot PRs were failing the [commit-lint check](https://github.com/SocketDev/socket-basics/actions/workflows/commit-lint.yml) introduced in #46 since it uses its own title format. Adding `commit-message` prefix config to `dependabot.yml` so future Dependabot PRs emit conventional-style titles `(chore(deps): ...,
ci(deps): ...)` natively. Also adds guidance in the PR template for [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)-compliant PR titles.