### PR TITLE
fix: remove trivy from Docker build while assessing compromise impact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG UV_VERSION=0.10.11
 ARG OPENGREP_VERSION=v1.16.5
 
 # ─── Stage: trivy (Dependabot-trackable) ──────────────────────────────────────
-FROM aquasec/trivy:${TRIVY_VERSION} AS trivy
+# FROM aquasec/trivy:${TRIVY_VERSION} AS trivy
 
 # ─── Stage: trufflehog (Dependabot-trackable) ─────────────────────────────────
 FROM trufflesecurity/trufflehog:${TRUFFLEHOG_VERSION} AS trufflehog
@@ -42,7 +42,7 @@ WORKDIR /socket-basics
 COPY --from=uv /uv /uvx /bin/
 
 # Binary tools from immutable build stages
-COPY --from=trivy      /usr/local/bin/trivy      /usr/local/bin/trivy
+# COPY --from=trivy      /usr/local/bin/trivy      /usr/local/bin/trivy
 COPY --from=trufflehog /usr/bin/trufflehog        /usr/local/bin/trufflehog
 COPY --from=opengrep-installer /root/.opengrep    /root/.opengrep
 

--- a/scripts/smoke-test-docker.sh
+++ b/scripts/smoke-test-docker.sh
@@ -13,16 +13,20 @@ BUILD_PROGRESS="${SMOKE_TEST_BUILD_PROGRESS:-}"
 MAIN_TOOLS=(
   "socket-basics -h"
   "command -v socket"
-  "trivy --version"
   "trufflehog --version"
   "opengrep --version"
 )
 
 APP_TESTS_TOOLS=(
-  "trivy --version"
   "trufflehog --version"
   "opengrep --version"
   "command -v socket"
+)
+
+# TEMPORARY: trivy is being removed to assess impact. These checks FAIL if the
+# tool is still present in the image — ensures removal is complete.
+MUST_NOT_EXIST_TOOLS=(
+  "trivy"
 )
 
 usage() {
@@ -104,6 +108,22 @@ run_checks() {
   done
 }
 
+# TEMPORARY: verify tools have been fully removed from the image.
+# Fails if any tool in the list is still present.
+run_must_not_exist_checks() {
+  local tag="$1"
+  shift
+  local tools=("$@")
+  for tool in "${tools[@]}"; do
+    if docker run --rm --entrypoint /bin/sh "$tag" -c "command -v $tool" > /dev/null 2>&1; then
+      echo "  FAIL: $tool is still present in the image (expected removal)"
+      return 1
+    else
+      echo "  OK: $tool not found (removal confirmed)"
+    fi
+  done
+}
+
 cd "$REPO_ROOT"
 
 if $SKIP_BUILD; then
@@ -116,6 +136,7 @@ if $SKIP_BUILD; then
   else
     run_checks "$IMAGE_TAG" "${MAIN_TOOLS[@]}"
   fi
+  run_must_not_exist_checks "$IMAGE_TAG" "${MUST_NOT_EXIST_TOOLS[@]}"
 else
   # ── Normal mode: build then verify ────────────────────────────────────────
   echo "==> Build main image"
@@ -129,6 +150,7 @@ else
 
   echo "==> Verify tools in main image"
   run_checks "$IMAGE_TAG" "${MAIN_TOOLS[@]}"
+  run_must_not_exist_checks "$IMAGE_TAG" "${MUST_NOT_EXIST_TOOLS[@]}"
 
   if $RUN_APP_TESTS; then
     echo "==> Build app_tests image"
@@ -141,6 +163,7 @@ else
 
     echo "==> Verify tools in app_tests image"
     run_checks "$APP_TESTS_IMAGE_TAG" "${APP_TESTS_TOOLS[@]}"
+    run_must_not_exist_checks "$APP_TESTS_IMAGE_TAG" "${MUST_NOT_EXIST_TOOLS[@]}"
   fi
 fi
 


### PR DESCRIPTION
<!-- PR TITLE: use Conventional Commits format — the commit-lint CI check enforces this.
     type(scope): Description    →    feat(docker): Add versioned Node stage
     Valid types: feat · fix · docs · chore · ci · refactor · test · perf · revert
     Breaking change: add ! after type  →  feat!: Switch to pre-built images -->

## Summary

<!-- What does this PR do? Why? -->

## Changes

<!-- Bullet points are fine. Link to relevant issues/tickets if applicable. -->
- Removing Trivy from the image until we confirm the impact of their compromise

## Testing

<!-- How was this tested? Local smoke test, CI, manual verification, etc. -->

---

### Release checklist (skip for non-release PRs)

<!-- Only fill this out if this PR is cutting a new release (e.g. v2.1.0). -->

- [ ] `socket_basics/version.py` updated to new version
- [ ] `pyproject.toml` `version:` field updated to match
- [ ] `action.yml` `image:` ref updated to `docker://ghcr.io/socketdev/socket-basics:<new-version>` *(auto-updated by `publish-docker.yml` after v2.0.0; manual update required only for the initial v2.0.0 release)*
- [ ] `CHANGELOG.md` `[Unreleased]` section reviewed *(note: this content is replaced by auto-generated release notes when the tag fires — see [docs/releasing.md](../docs/releasing.md#changelog-and-release-notes))*

> ⚠️ **After merging:** run `publish-docker.yml` via `workflow_dispatch` with the new version
> **before** creating the git tag. The image must exist in GHCR before the tag is pushed.
> See [docs/releasing.md](../docs/releasing.md) for the full process.
