### PR TITLE
fix: Harden GHA workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"   # → chore(deps): bump trivy from 0.69.2 to 0.69.3
+    cooldown:
+      default-days: 7
 
   # app_tests Dockerfile — same as above, plus golang and securego/gosec.
   - package-ecosystem: "docker"
@@ -27,6 +29,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   # GitHub Actions — tracks all uses: ... action versions.
   - package-ecosystem: "github-actions"
@@ -39,3 +43,5 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"   # → ci(deps): bump actions/checkout from v3 to v4
+    cooldown:
+      default-days: 7

--- a/.github/workflows/_docker-pipeline.yml
+++ b/.github/workflows/_docker-pipeline.yml
@@ -113,6 +113,7 @@ jobs:
       - name: 🔨 Build (load for testing)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
+          # zizmor: ignore[template-injection] — safe: always hardcoded "." from same-repo callers; passed as array element to exec, not shell-interpolated
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           load: true
@@ -132,18 +133,23 @@ jobs:
 
       # ── Step 2: Smoke test ─────────────────────────────────────────────────
       - name: 🧪 Smoke test
+        env:
+          IMAGE_NAME: ${{ inputs.name }}
+          CHECK_SET: ${{ inputs.check_set }}
         run: |
           bash ./scripts/smoke-test-docker.sh \
             --skip-build \
-            --image-tag ${{ inputs.name }}:pipeline-test \
-            --check-set ${{ inputs.check_set }}
+            --image-tag "$IMAGE_NAME:pipeline-test" \
+            --check-set "$CHECK_SET"
 
       # ── Step 3: Integration test (main image only) ─────────────────────────
       - name: 🔬 Integration test
         if: inputs.name == 'socket-basics'
+        env:
+          IMAGE_NAME: ${{ inputs.name }}
         run: |
           bash ./scripts/integration-test-docker.sh \
-            --image-tag ${{ inputs.name }}:pipeline-test
+            --image-tag "$IMAGE_NAME:pipeline-test"
 
       # ── Step 4: Push to registries (publish mode only) ─────────────────────
       # Docker Hub login happens here — after build and tests, immediately before
@@ -161,6 +167,7 @@ jobs:
         if: inputs.push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
+          # zizmor: ignore[template-injection] — safe: always hardcoded "." from same-repo callers; passed as array element to exec, not shell-interpolated
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           load: false

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -45,11 +45,15 @@ jobs:
 
       - name: 🏷️ Resolve version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            CLEAN="${{ inputs.tag }}"      # full tag as provided (e.g. 1.1.3 or v2.0.0)
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            CLEAN="$INPUT_TAG"      # full tag as provided (e.g. 1.1.3 or v2.0.0)
           else
-            CLEAN="${{ github.ref_name }}" # e.g. v2.0.0
+            CLEAN="$REF_NAME"      # e.g. v2.0.0
           fi
           CLEAN="${CLEAN#v}"               # strip leading v if present → 2.0.0 or 1.1.3
           echo "clean=$CLEAN" >> "$GITHUB_OUTPUT"
@@ -71,7 +75,9 @@ jobs:
       push: true
       tag_push: ${{ github.ref_type == 'tag' }}
       version: ${{ needs.resolve-version.outputs.version }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # ── Job 3: Create GitHub release + update CHANGELOG ────────────────────────
   # Runs once after the image is successfully pushed (not for workflow_dispatch
@@ -102,30 +108,35 @@ jobs:
           repositories: socket-basics
 
       - name: 📝 Create GitHub release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
+          gh release create "$REF_NAME" \
+            --title "$REF_NAME" \
             --generate-notes \
             --verify-tag \
           || echo "Release already exists (re-run scenario) — skipping creation"
-        env:
-          GH_TOKEN: ${{ steps.bot.outputs.token }}
 
       - name: 📋 Update CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          NOTES=$(gh release view "${{ github.ref_name }}" --json body --jq .body)
+          NOTES=$(gh release view "$REF_NAME" --json body --jq .body)
           DATE=$(date +%Y-%m-%d)
           echo "$NOTES" | python scripts/update_changelog.py \
             --version "$VERSION" \
             --date "$DATE"
-        env:
-          GH_TOKEN: ${{ steps.bot.outputs.token }}
 
       - name: 🔀 Commit CHANGELOG + action.yml back to main
+        env:
+          BOT_TOKEN: ${{ steps.bot.outputs.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config user.name "socket-release-bot[bot]"
           git config user.email "socket-release-bot[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ steps.bot.outputs.token }}@github.com/SocketDev/socket-basics.git"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/SocketDev/socket-basics.git"
 
           # Auto-update action.yml image ref to the new version.
           # No-op if action.yml still uses `image: "Dockerfile"` (handles the
@@ -138,5 +149,5 @@ jobs:
           fi
 
           git add CHANGELOG.md action.yml
-          git diff --cached --quiet || git commit -m "chore: release ${{ github.ref_name }} — update CHANGELOG and action.yml [skip ci]"
+          git diff --cached --quiet || git commit -m "chore: release ${REF_NAME} — update CHANGELOG and action.yml [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,4 +38,3 @@ jobs:
       context: .
       check_set: main
       push: false
-    secrets: inherit

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
## Summary
- **Template injection fixes**: Moved 9 `${{ }}` expressions out of `run:` blocks into `env:` variables across `_docker-pipeline.yml` and `publish-docker.yml`, preventing potential command injection via attacker-controlled GitHub context values
- **Least-privilege secrets**: Replaced `secrets: inherit` with explicit `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` passing in `publish-docker.yml`; removed unnecessary secret passing from `smoke-test.yml` (it sets `push: false`, so Docker Hub creds are never used)
- **Zizmor suppression comments**: Added `ignore[template-injection]` on the two `docker/build-push-action` `context:` inputs — these are false positives (hardcoded `"."` from same-repo callers, array-based exec not shell interpolation)
- **Zizmor config**: Added `.github/zizmor.yml` disabling `secrets-outside-env` (org-wide decision)