### PR TITLE
feat: add pr_comment_enabled and pr_comment_collapse_all PR comment controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ Socket Basics can also run locally or in other CI/CD environments:
 Socket Basics delivers **beautifully formatted, actionable PR comments** with smart defaults — all enabled by default, zero configuration needed.
 
 - 🔗 **Clickable File Links** — Jump directly to the vulnerable code in GitHub
-- 📋 **Collapsible Sections** — Critical findings auto-expand, others collapse
+- 📋 **Collapsible Sections** — SAST and Socket Tier 1 findings collapse, critical ones auto-expand; `pr_comment_collapse_all: 'true'` closes those too
 - 🎨 **Syntax Highlighting** — Language-aware code blocks
 - 🏷️ **Auto-Labels** — PRs tagged with severity-based labels (e.g., `security: critical`)
 - 🔴 **CVE Links & CVSS Scores** — One-click access to NVD with risk context
 - 🚀 **Full Scan Link** — Report link prominently displayed at the top
+- 🔇 **Fully Suppressible** — `pr_comment_enabled: 'false'` stops the comment entirely while the scan still runs, still uploads to the Socket dashboard, and still fails the job on high/critical findings
 
 Every feature is customizable via GitHub Actions inputs, CLI flags, or environment variables.
 

--- a/action.yml
+++ b/action.yml
@@ -91,9 +91,11 @@ runs:
     INPUT_WEBHOOK_URL: ${{ inputs.webhook_url }}
     SOCKET_ADDITIONAL_PARAMS: ${{ inputs.socket_additional_params }}
     SOCKET_TIER_1_ENABLED: ${{ inputs.socket_tier_1_enabled }}
+    INPUT_PR_COMMENT_ENABLED: ${{ inputs.pr_comment_enabled }}
     INPUT_PR_COMMENT_LINKS_ENABLED: ${{ inputs.pr_comment_links_enabled }}
     INPUT_PR_COMMENT_COLLAPSE_ENABLED: ${{ inputs.pr_comment_collapse_enabled }}
     INPUT_PR_COMMENT_COLLAPSE_NON_CRITICAL: ${{ inputs.pr_comment_collapse_non_critical }}
+    INPUT_PR_COMMENT_COLLAPSE_ALL: ${{ inputs.pr_comment_collapse_all }}
     INPUT_PR_COMMENT_CODE_FENCING_ENABLED: ${{ inputs.pr_comment_code_fencing_enabled }}
     INPUT_PR_COMMENT_SHOW_RULE_NAMES: ${{ inputs.pr_comment_show_rule_names }}
     INPUT_PR_LABELS_ENABLED: ${{ inputs.pr_labels_enabled }}
@@ -442,6 +444,15 @@ inputs:
     description: "Generic webhook URL for WebhookNotifier"
     required: false
     default: ""
+  pr_comment_enabled:
+    description: >-
+      Post the findings comment on the pull request. Set to 'false' to run the
+      scan silently: findings are still uploaded to the Socket dashboard and the
+      action still fails the job on high/critical findings, but no comment is
+      posted or updated. Severity labels are controlled separately by
+      pr_labels_enabled.
+    required: false
+    default: "true"
   pr_comment_links_enabled:
     description: "Enable clickable file/line links in PR comments"
     required: false
@@ -454,6 +465,15 @@ inputs:
     description: "Auto-collapse non-critical findings (critical stays expanded)"
     required: false
     default: "true"
+  pr_comment_collapse_all:
+    description: >-
+      Collapse the SAST and Socket Tier 1 sections, critical findings included.
+      Those are the sections built from collapsible panels, so they are the
+      ones this can close. Secret findings and Dockerfile findings render as
+      plain tables and stay fully visible, and each collapsed section still
+      shows its summary row. Overrides pr_comment_collapse_non_critical.
+    required: false
+    default: "false"
   pr_comment_code_fencing_enabled:
     description: "Enable language-aware code fencing for trace output"
     required: false

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -328,6 +328,8 @@ jobs:
 
 Socket Basics automatically posts enhanced PR comments with **smart defaults that work out of the box** — clickable file links, collapsible sections, syntax highlighting, CVE links, CVSS scores, and auto-labels are all enabled by default.
 
+To run the scan without commenting on the PR at all, set `pr_comment_enabled: 'false'`. The scan still runs, findings are still uploaded to the Socket dashboard, and the job still fails on high/critical findings — only the comment is suppressed. If you want a quieter comment rather than no comment, `pr_comment_collapse_all: 'true'` closes the SAST and Socket Tier 1 sections, critical findings included.
+
 📖 **[PR Comment Guide →](github-pr-comment-guide.md)** — Complete customization options, configuration examples, and reference table
 
 ## Enterprise Features

--- a/docs/github-pr-comment-guide.md
+++ b/docs/github-pr-comment-guide.md
@@ -89,7 +89,23 @@ pr_comment_collapse_enabled: 'false'
 # Keep collapsible but expand everything
 pr_comment_collapse_enabled: 'true'
 pr_comment_collapse_non_critical: 'false'
+
+# Keep collapsible and collapse the SAST and Tier 1 sections, critical included
+pr_comment_collapse_enabled: 'true'
+pr_comment_collapse_all: 'true'
 ```
+
+> [!NOTE]
+> `pr_comment_collapse_non_critical` deliberately leaves critical findings
+> expanded, so a single critical finding always opens the comment. Set
+> `pr_comment_collapse_all: 'true'` to close those sections too. It overrides
+> `pr_comment_collapse_non_critical`.
+>
+> The flag reaches the sections that are built from collapsible panels, which
+> are the SAST findings and the Socket Tier 1 findings. Secret findings and
+> Dockerfile findings render as plain markdown tables, so they stay fully
+> visible either way, and every collapsed SAST section still shows one summary
+> row per file.
 
 ---
 
@@ -290,7 +306,48 @@ The logo is a 32px PNG rendered at 24x24 for retina-crisp display, with a transp
 
 ---
 
-### 9. All-Clear Comment Updates
+### 9. Turning the Comment Off (`pr_comment_enabled`)
+
+**Default:** `true`
+
+Set `pr_comment_enabled: 'false'` to run the scan without saying anything on the
+PR. This is for teams who want to review finding quality in the Socket dashboard
+first, without every PR growing a comment that developers have to scroll past.
+
+```yaml
+- uses: SocketDev/socket-basics@v2
+  with:
+    socket_security_api_key: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    pr_comment_enabled: 'false'
+```
+
+**What still happens when the comment is off:**
+
+| Behavior | Still happens? |
+|----------|----------------|
+| Scanners run (SAST, secrets, containers) | ✅ Yes |
+| Findings uploaded to the Socket dashboard | ✅ Yes |
+| `.socket.facts.json` written | ✅ Yes |
+| Job fails on high/critical findings | ✅ Yes |
+| Other notifiers (Slack, Jira, webhook, ...) | ✅ Yes |
+| Severity labels added to the PR | ✅ Yes, unless `pr_labels_enabled: 'false'` |
+| Comment posted or updated | ❌ No |
+
+Notifiers are the very last thing the run does — the scan finishes and the
+findings are uploaded to Socket before any comment would be posted — so turning
+the comment off cannot turn the dashboard off. Labels are a separate switch
+(`pr_labels_enabled`) so you can keep or drop them independently.
+
+> [!TIP]
+> If you want to keep the comment but make it quieter, use
+> `pr_comment_collapse_all: 'true'` instead. That closes the SAST and Socket
+> Tier 1 sections, critical findings included, so those sections are down to a
+> summary row until someone opens them.
+
+---
+
+### 10. All-Clear Comment Updates
 
 When a later Socket Basics run no longer has active findings for a previously-reported scanner section, the existing PR comment section is updated in place instead of being left stale or deleted.
 
@@ -312,9 +369,11 @@ When a later Socket Basics run no longer has active findings for a previously-re
 
 | Option | Default | Type | Description |
 |--------|---------|------|-------------|
+| `pr_comment_enabled` | `true` | boolean | Post/update the findings comment on the PR |
 | `pr_comment_links_enabled` | `true` | boolean | Enable clickable file/line links |
 | `pr_comment_collapse_enabled` | `true` | boolean | Enable collapsible sections |
-| `pr_comment_collapse_non_critical` | `true` | boolean | Auto-collapse non-critical findings |
+| `pr_comment_collapse_non_critical` | `true` | boolean | Auto-collapse non-critical findings (critical stays expanded) |
+| `pr_comment_collapse_all` | `false` | boolean | Collapse the SAST and Socket Tier 1 sections, critical included |
 | `pr_comment_code_fencing_enabled` | `true` | boolean | Enable syntax highlighting |
 | `pr_comment_show_rule_names` | `true` | boolean | Show explicit rule names |
 | `pr_labels_enabled` | `true` | boolean | Add severity-based labels to PRs |
@@ -322,6 +381,18 @@ When a later Socket Basics run no longer has active findings for a previously-re
 | `pr_label_high` | `"security: high"` | string | Label name for high findings |
 | `pr_label_medium` | `"security: medium"` | string | Label name for medium findings |
 | `pr_label_low` | `"security: low"` | string | Label name for low findings |
+
+### How boolean options are read
+
+Every boolean above accepts `true`, `1`, `yes` and `on` for on, and `false`,
+`0`, `no` and `off` for off, in any capitalization, whether it arrives as a
+GitHub Action input, an environment variable, a `--config` JSON file, or a
+Socket dashboard config.
+
+A value that says nothing — blank, whitespace, or a word that is neither — falls
+back to the default in the table. This matters for `pr_comment_enabled`: passing
+it a workflow variable that turns out to be unset gives the action an empty
+string, and that leaves the comment on rather than silently switching it off.
 
 ### Configuration Methods
 
@@ -392,6 +463,22 @@ pr_comment_collapse_non_critical: 'true'
 pr_label_critical: 'security'
 pr_label_high: 'security'
 pr_label_medium: 'security'
+```
+
+### Evaluation / Trial (Dashboard Only)
+
+Review findings in the Socket dashboard without putting anything on the PR:
+```yaml
+pr_comment_enabled: 'false'
+pr_labels_enabled: 'false'
+```
+
+### Quiet Comment (Collapsible Sections Closed)
+
+Keep the SAST and Socket Tier 1 sections closed even when there are critical
+findings:
+```yaml
+pr_comment_collapse_all: 'true'
 ```
 
 ---

--- a/docs/github-pr-comment-guide.md
+++ b/docs/github-pr-comment-guide.md
@@ -315,7 +315,7 @@ PR. This is for teams who want to review finding quality in the Socket dashboard
 first, without every PR growing a comment that developers have to scroll past.
 
 ```yaml
-- uses: SocketDev/socket-basics@v2
+- uses: SocketDev/socket-basics@v3.0.0
   with:
     socket_security_api_key: ${{ secrets.SOCKET_SECURITY_API_KEY }}
     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/preview_pr_comments.py
+++ b/scripts/preview_pr_comments.py
@@ -36,6 +36,7 @@ def make_mock_config(
     repo="SocketDev/example-app",
     commit="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
     full_scan_url="https://socket.dev/dashboard/scan/12345",
+    collapse_all=False,
 ):
     """Build a mock config object matching the real pipeline shape."""
     return MockConfig(
@@ -44,6 +45,7 @@ def make_mock_config(
         pr_comment_links_enabled=True,
         pr_comment_collapse_enabled=True,
         pr_comment_collapse_non_critical=True,
+        pr_comment_collapse_all=collapse_all,
         pr_comment_code_fencing_enabled=True,
         pr_comment_show_rule_names=True,
         full_scan_html_url=full_scan_url,

--- a/socket_basics/core/config.py
+++ b/socket_basics/core/config.py
@@ -14,6 +14,38 @@ from typing import Dict, Any, List, Optional
 
 logger = logging.getLogger(__name__)
 
+TRUE_STRINGS = ('true', '1', 'yes', 'on')
+FALSE_STRINGS = ('false', '0', 'no', 'off')
+
+
+def coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce a config value to a bool, tolerating the string forms.
+
+    Every layer that carries a flag delivers it differently: the environment
+    loader sees strings because GitHub Action inputs are always strings, a
+    Socket dashboard config can send either, and a JSON config sends real
+    booleans. ``bool("false")`` is ``True``, so a plain cast turns a disabled
+    flag back on.
+
+    A value that says nothing -- ``None``, an empty string, or a word that is
+    neither true nor false -- resolves to ``default`` rather than to ``False``.
+    An action input forwarded from an unset workflow variable arrives as an
+    empty string, and reading that as "off" silently disables a flag that
+    nobody asked to disable.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in TRUE_STRINGS:
+            return True
+        if normalized in FALSE_STRINGS:
+            return False
+        return default
+    return bool(value)
+
 
 def _normalize_path_parts(path_value: str | None) -> List[str] | None:
     """Normalize a path-like string into comparable POSIX-style path segments."""
@@ -796,36 +828,32 @@ def load_config_from_env() -> Dict[str, Any]:
     
     # Also load notification parameters from notifications.yaml so CLI/env can enable them
     try:
-        base_dir = Path(__file__).parent.parent
-        notif_path = base_dir / 'notifications.yaml'
-        if notif_path.exists():
-            with open(notif_path, 'r') as f:
-                notif_cfg = yaml.safe_load(f) or {}
-            for n_name, n_cfg in (notif_cfg.get('notifiers') or {}).items():
-                for param in n_cfg.get('parameters', []) or []:
-                    p_name = param.get('name')
-                    env_var = param.get('env_variable')
-                    p_type = param.get('type', 'str')
-                    default_value = param.get('default', '' if p_type != 'bool' else False)
+        notif_cfg = load_notifications_config()
+        for n_name, n_cfg in (notif_cfg.get('notifiers') or {}).items():
+            for param in n_cfg.get('parameters', []) or []:
+                p_name = param.get('name')
+                env_var = param.get('env_variable')
+                p_type = param.get('type', 'str')
+                default_value = param.get('default', '' if p_type != 'bool' else False)
 
-                    if p_name and env_var:
-                        env_value = os.getenv(env_var)
-                        if env_value is not None:
-                            if p_type == 'bool':
-                                config[p_name] = env_value.lower() == 'true'
-                            elif p_type == 'int':
-                                try:
-                                    config[p_name] = int(env_value)
-                                except ValueError:
-                                    logging.getLogger(__name__).warning(
-                                        "Invalid integer for %s (env %s): %s; using default %s",
-                                        p_name, env_var, env_value, default_value
-                                    )
-                                    config[p_name] = default_value
-                            else:
-                                config[p_name] = env_value
+                if p_name and env_var:
+                    env_value = os.getenv(env_var)
+                    if env_value is not None:
+                        if p_type == 'bool':
+                            config[p_name] = coerce_bool(env_value, bool(default_value))
+                        elif p_type == 'int':
+                            try:
+                                config[p_name] = int(env_value)
+                            except ValueError:
+                                logging.getLogger(__name__).warning(
+                                    "Invalid integer for %s (env %s): %s; using default %s",
+                                    p_name, env_var, env_value, default_value
+                                )
+                                config[p_name] = default_value
                         else:
-                            config[p_name] = default_value
+                            config[p_name] = env_value
+                    else:
+                        config[p_name] = default_value
     except Exception:
         # Best-effort; do not fail on notification parsing
         pass
@@ -1322,6 +1350,84 @@ def load_connectors_config() -> Dict[str, Any]:
         return {}
 
 
+def load_notifications_config() -> Dict[str, Any]:
+    """Load notifier configuration from notifications.yaml"""
+    try:
+        base_dir = Path(__file__).parent.parent  # Go up from core to socket_basics
+        config_path = base_dir / "notifications.yaml"
+
+        if not config_path.exists():
+            return {}
+
+        with open(config_path, 'r') as f:
+            return yaml.safe_load(f) or {}
+    except Exception as e:
+        logging.getLogger(__name__).warning("Warning: Could not load notifications config: %s", e)
+        return {}
+
+
+def _add_bool_cli_arg(parser: argparse.ArgumentParser, option: str, default: Any, description: str):
+    """Register a boolean CLI flag declared in connectors.yaml or notifications.yaml.
+
+    A flag that is already on cannot be turned off by a plain ``store_true``
+    option, so a parameter declaring ``default: true`` gets argparse's paired
+    ``--flag`` / ``--no-flag`` form instead.
+
+    Either form parses to ``None`` when the option is absent. That is what lets
+    the config layer tell "the user said nothing" apart from "the user said
+    false", so an unused flag never overwrites a value that came from the
+    environment, a JSON config or the Socket dashboard.
+    """
+    if coerce_bool(default, False):
+        parser.add_argument(option, action=argparse.BooleanOptionalAction,
+                            default=None, help=description)
+    else:
+        parser.add_argument(option, action='store_true', default=None, help=description)
+
+
+def _apply_param_cli_overrides(config_dict: Dict[str, Any], args, params: List[Dict[str, Any]]):
+    """Copy CLI values for YAML-declared parameters into the effective config.
+
+    ``params`` is the ``parameters`` list of one connector (connectors.yaml) or
+    one notifier (notifications.yaml). Both files describe their options the
+    same way, so both are copied by this one function and a notifier flag
+    reaches the config exactly like a connector flag does.
+    """
+    for param in params or []:
+        param_name = param.get('name')
+        option = param.get('option')
+
+        if not param_name or not option:
+            continue
+
+        # Convert option like "--python" to attribute name "python"
+        arg_name = option.lstrip('-').replace('-', '_')
+
+        if not hasattr(args, arg_name):
+            continue
+
+        arg_value = getattr(args, arg_name)
+        if arg_value is None:
+            # The option was not passed, so leave the existing config alone.
+            continue
+
+        if param.get('type') == 'bool':
+            config_dict[param_name] = bool(arg_value)
+
+            if arg_value:
+                # Handle enables/disables attributes
+                for enabled_param in param.get('enables', []):
+                    config_dict[enabled_param] = True
+
+                for disabled_param in param.get('disables', []):
+                    config_dict[disabled_param] = False
+
+        elif arg_value:
+            # Only override config for non-bool types if CLI arg has a value.
+            # This prevents empty string defaults from wiping out env/API config.
+            config_dict[param_name] = arg_value
+
+
 def add_dynamic_cli_args(parser: argparse.ArgumentParser):
     """Add CLI arguments based on connectors configuration"""
     try:
@@ -1335,10 +1441,9 @@ def add_dynamic_cli_args(parser: argparse.ArgumentParser):
                     
                 param_type = param.get('type', 'str')
                 description = param.get('description', f"Enable {connector_name}")
-                default = param.get('default')
-                
+
                 if param_type == 'bool':
-                    parser.add_argument(option, action='store_true', help=description)
+                    _add_bool_cli_arg(parser, option, param.get('default'), description)
                 elif param_type == 'str':
                     parser.add_argument(option, type=str, default=None, help=description)
                 elif param_type == 'int':
@@ -1356,25 +1461,20 @@ def add_dynamic_cli_args(parser: argparse.ArgumentParser):
 
     # Also add CLI args for notification plugins declared in notifications.yaml
     try:
-        base_dir = Path(__file__).parent.parent
-        notif_path = base_dir / 'notifications.yaml'
-        if notif_path.exists():
-            with open(notif_path, 'r') as f:
-                notif_cfg = yaml.safe_load(f) or {}
-            for n_name, n_cfg in (notif_cfg.get('notifiers') or {}).items():
-                for param in n_cfg.get('parameters', []) or []:
-                    option = param.get('option')
-                    p_type = param.get('type', 'str')
-                    desc = param.get('description', f"Notification parameter for {n_name}")
-                    default = param.get('default')
-                    if not option:
-                        continue
-                    if p_type == 'bool':
-                        parser.add_argument(option, action='store_true', help=desc)
-                    elif p_type == 'int':
-                        parser.add_argument(option, type=int, default=None, help=desc)
-                    else:
-                        parser.add_argument(option, type=str, default=None, help=desc)
+        notif_cfg = load_notifications_config()
+        for n_name, n_cfg in (notif_cfg.get('notifiers') or {}).items():
+            for param in n_cfg.get('parameters', []) or []:
+                option = param.get('option')
+                p_type = param.get('type', 'str')
+                desc = param.get('description', f"Notification parameter for {n_name}")
+                if not option:
+                    continue
+                if p_type == 'bool':
+                    _add_bool_cli_arg(parser, option, param.get('default'), desc)
+                elif p_type == 'int':
+                    parser.add_argument(option, type=int, default=None, help=desc)
+                else:
+                    parser.add_argument(option, type=str, default=None, help=desc)
     except Exception:
         pass
 
@@ -1503,38 +1603,20 @@ def create_config_from_args(args) -> Config:
         if os.getenv('SOCKET_S3_ENABLED', '').lower() in ('true', '1', 'yes'):
             config_dict['enable_s3_upload'] = True
     
-    # Dynamically apply connector parameters from CLI args
+    # Dynamically apply connector and notifier parameters from CLI args.
+    # Notifiers register their own CLI options in add_dynamic_cli_args, so they
+    # have to be copied here too or a parsed notifier flag never reaches the
+    # effective config.
     try:
         connectors_config = load_connectors_config()
-        
-        for connector_name, connector_config in connectors_config.get('connectors', {}).items():
-            for param in connector_config.get('parameters', []):
-                param_name = param.get('name')
-                option = param.get('option')
-                
-                if param_name and option:
-                    # Convert option like "--python" to attribute name "python"
-                    arg_name = option.lstrip('-').replace('-', '_')
-                    
-                    if hasattr(args, arg_name):
-                        arg_value = getattr(args, arg_name)
-                        if arg_value is not None:
-                            if param.get('type') == 'bool' and arg_value:
-                                config_dict[param_name] = True
-                                
-                                # Handle enables/disables attributes
-                                if 'enables' in param:
-                                    for enabled_param in param['enables']:
-                                        config_dict[enabled_param] = True
-                                        
-                                if 'disables' in param:
-                                    for disabled_param in param['disables']:
-                                        config_dict[disabled_param] = False
-                                        
-                            elif param.get('type') != 'bool' and arg_value:
-                                # Only override config for non-bool types if CLI arg has a value
-                                # This prevents empty string defaults from wiping out env/API config
-                                config_dict[param_name] = arg_value
+
+        for connector_config in connectors_config.get('connectors', {}).values():
+            _apply_param_cli_overrides(config_dict, args, connector_config.get('parameters', []))
+
+        notifications_config = load_notifications_config()
+
+        for notifier_config in (notifications_config.get('notifiers') or {}).values():
+            _apply_param_cli_overrides(config_dict, args, notifier_config.get('parameters', []))
     except Exception as e:
         logging.getLogger(__name__).warning("Warning: Error processing dynamic CLI args: %s", e)
     

--- a/socket_basics/core/connector/opengrep/github_pr.py
+++ b/socket_basics/core/connector/opengrep/github_pr.py
@@ -34,6 +34,7 @@ def format_notifications(groups: Dict[str, List[Dict[str, Any]]], config=None) -
     enable_links = flags['enable_links']
     enable_collapse = flags['enable_collapse']
     collapse_non_critical = flags['collapse_non_critical']
+    collapse_all = flags['collapse_all']
     enable_code_fencing = flags['enable_code_fencing']
     show_rule_names = flags['show_rule_names']
     repository = flags['repository']
@@ -202,8 +203,10 @@ def format_notifications(groups: Dict[str, List[Dict[str, Any]]], config=None) -
                 if enable_collapse:
                     # Determine if this should be auto-expanded
                     has_critical = file_severities['critical'] > 0
-                    # Auto-expand if: no collapse requested OR has critical findings
-                    auto_expand = (not collapse_non_critical) or has_critical
+                    # Auto-expand if: no collapse requested OR has critical findings.
+                    # collapse_all wins over both so the comment can stay small
+                    # even when a critical finding is present.
+                    auto_expand = ((not collapse_non_critical) or has_critical) and not collapse_all
 
                     collapsible = helpers.create_collapsible_section(
                         display_path,  # Don't use backticks in summary - they don't render in GitHub

--- a/socket_basics/core/connector/socket_tier1/github_pr.py
+++ b/socket_basics/core/connector/socket_tier1/github_pr.py
@@ -34,6 +34,7 @@ def format_notifications(components_list: List[Dict[str, Any]], config=None) -> 
     enable_links = flags['enable_links']
     enable_collapse = flags['enable_collapse']
     collapse_non_critical = flags['collapse_non_critical']
+    collapse_all = flags['collapse_all']
     enable_code_fencing = flags['enable_code_fencing']
     show_rule_names = flags['show_rule_names']
     repository = flags['repository']
@@ -154,7 +155,10 @@ def format_notifications(components_list: List[Dict[str, Any]], config=None) -> 
 
                 severity_summary = " | ".join(severity_parts) if severity_parts else "No issues"
 
-                open_attr = ' open' if (not collapse_non_critical or has_critical) else ''
+                # collapse_all wins over both so the comment can stay small even
+                # when a critical finding is present.
+                auto_expand = (not collapse_non_critical or has_critical) and not collapse_all
+                open_attr = ' open' if auto_expand else ''
                 content_lines.append(f"<details{open_attr}>")
                 content_lines.append(f"<summary><strong>{purl}</strong> ({severity_summary})</summary>")
                 content_lines.append("")

--- a/socket_basics/core/notification/github_pr_helpers.py
+++ b/socket_basics/core/notification/github_pr_helpers.py
@@ -14,6 +14,10 @@ import re
 from typing import Dict, Any, Optional, List, Tuple
 from pathlib import Path
 
+# coerce_bool lives in the config layer so the environment loader, a Socket
+# dashboard config and these flags all read a string the same way.
+from socket_basics.core.config import coerce_bool
+
 
 # ============================================================================
 # Severity Constants (shared across all scanners)
@@ -99,6 +103,7 @@ def get_feature_flags(config) -> Dict[str, Any]:
             'enable_links': True,
             'enable_collapse': True,
             'collapse_non_critical': True,
+            'collapse_all': False,
             'enable_code_fencing': True,
             'show_rule_names': True,
             'repository': '',
@@ -107,11 +112,12 @@ def get_feature_flags(config) -> Dict[str, Any]:
         }
 
     return {
-        'enable_links': config.get('pr_comment_links_enabled', True),
-        'enable_collapse': config.get('pr_comment_collapse_enabled', True),
-        'collapse_non_critical': config.get('pr_comment_collapse_non_critical', True),
-        'enable_code_fencing': config.get('pr_comment_code_fencing_enabled', True),
-        'show_rule_names': config.get('pr_comment_show_rule_names', True),
+        'enable_links': coerce_bool(config.get('pr_comment_links_enabled'), True),
+        'enable_collapse': coerce_bool(config.get('pr_comment_collapse_enabled'), True),
+        'collapse_non_critical': coerce_bool(config.get('pr_comment_collapse_non_critical'), True),
+        'collapse_all': coerce_bool(config.get('pr_comment_collapse_all'), False),
+        'enable_code_fencing': coerce_bool(config.get('pr_comment_code_fencing_enabled'), True),
+        'show_rule_names': coerce_bool(config.get('pr_comment_show_rule_names'), True),
         'repository': config.repo if hasattr(config, 'repo') else '',
         'commit_hash': config.commit_hash if hasattr(config, 'commit_hash') else '',
         'full_scan_url': config.get('full_scan_html_url') if config else None

--- a/socket_basics/core/notification/github_pr_notifier.py
+++ b/socket_basics/core/notification/github_pr_notifier.py
@@ -3,6 +3,7 @@ import logging
 from urllib.parse import quote
 
 from socket_basics.core.notification.base import BaseNotifier
+from socket_basics.core.notification.github_pr_helpers import coerce_bool
 from socket_basics.core.config import get_github_token, get_github_repository, get_github_pr_number
 
 logger = logging.getLogger(__name__)
@@ -36,8 +37,9 @@ class GithubPRNotifier(BaseNotifier):
 
     def notify(self, facts: Dict[str, Any]) -> None:
         notifications = facts.get('notifications', []) or []
-        labels_enabled = self.config.get('pr_labels_enabled', True)
-        
+        labels_enabled = coerce_bool(self.config.get('pr_labels_enabled'), True)
+        comment_enabled = coerce_bool(self.config.get('pr_comment_enabled'), True)
+
         if not isinstance(notifications, list):
             logger.error('GithubPRNotifier: only supports new format - list of dicts with title/content')
             return
@@ -56,6 +58,24 @@ class GithubPRNotifier(BaseNotifier):
 
         notification_section_types = self._extract_section_types_from_notifications(valid_notifications)
         facts_section_types = self._infer_section_types_from_facts(facts)
+
+        # Comment suppression: the scan has already run and the findings have
+        # already been uploaded to the Socket dashboard by the time notifiers
+        # execute, so this only silences the PR comment. Severity labels stay
+        # under pr_labels_enabled so the two can be turned off independently.
+        if not comment_enabled:
+            logger.info(
+                'GithubPRNotifier: PR comments disabled (pr_comment_enabled=false); '
+                '%d finding section(s) were scanned and uploaded to the Socket dashboard '
+                'but no comment will be posted or updated',
+                len(valid_notifications),
+            )
+            if labels_enabled:
+                pr_number = self._get_pr_number()
+                if pr_number:
+                    labels = self._determine_pr_labels(valid_notifications)
+                    self._reconcile_pr_labels(pr_number, labels)
+            return
 
         if not valid_notifications:
             pr_number = self._get_pr_number()

--- a/socket_basics/notifications.yaml
+++ b/socket_basics/notifications.yaml
@@ -90,6 +90,12 @@ notifiers:
         option: --github-api-url
         env_variable: GITHUB_API_URL
         type: str
+      - name: pr_comment_enabled
+        option: --pr-comment
+        env_variable: INPUT_PR_COMMENT_ENABLED
+        type: bool
+        default: true
+        description: "Post/update the findings comment on the PR (scanning and dashboard upload are unaffected)"
       - name: pr_comment_links_enabled
         option: --pr-comment-links
         env_variable: INPUT_PR_COMMENT_LINKS_ENABLED
@@ -108,6 +114,12 @@ notifiers:
         type: bool
         default: true
         description: "Auto-collapse non-critical findings (critical stays expanded)"
+      - name: pr_comment_collapse_all
+        option: --pr-comment-collapse-all
+        env_variable: INPUT_PR_COMMENT_COLLAPSE_ALL
+        type: bool
+        default: false
+        description: "Collapse the SAST and Socket Tier 1 sections, critical findings included"
       - name: pr_comment_code_fencing_enabled
         option: --pr-comment-code-fencing
         env_variable: INPUT_PR_COMMENT_CODE_FENCING_ENABLED

--- a/tests/test_github_pr_notifier.py
+++ b/tests/test_github_pr_notifier.py
@@ -347,3 +347,140 @@ def test_notify_zero_alert_enabled_sast_config_rewrites_matching_section(monkeyp
     assert len(updated_bodies) == 1
     assert 'Socket Basics found no active findings in the latest run.' in updated_bodies[0]
     assert '<!-- sast-javascript start -->' in updated_bodies[0]
+
+
+# ---------------------------------------------------------------------------
+# pr_comment_enabled: suppress the PR comment without suppressing the scan
+# ---------------------------------------------------------------------------
+
+def _suppression_notifier(monkeypatch, **params):
+    """A notifier whose every GitHub write is recorded instead of performed."""
+    notifier = GithubPRNotifier({'repository': 'SocketDev/socket-basics', **params})
+    calls = {'posted': [], 'updated': [], 'labels': []}
+
+    monkeypatch.setattr(notifier, '_get_pr_number', lambda: 123)
+    monkeypatch.setattr(notifier, '_get_pr_comments', lambda pr_number: [])
+    monkeypatch.setattr(
+        notifier, '_post_comment', lambda pr_number, body: calls['posted'].append(body) or True
+    )
+    monkeypatch.setattr(
+        notifier,
+        '_update_comment',
+        lambda pr_number, comment_id, body: calls['updated'].append(body) or True,
+    )
+    monkeypatch.setattr(
+        notifier,
+        '_reconcile_pr_labels',
+        lambda pr_number, labels: calls['labels'].append(labels) or True,
+    )
+    return notifier, calls
+
+
+_FINDING = {
+    'title': 'Socket SAST JavaScript',
+    'content': '<!-- sast-javascript start -->\n🔴 Critical: 1\n<!-- sast-javascript end -->',
+}
+
+
+def test_notify_posts_comment_by_default(monkeypatch):
+    notifier, calls = _suppression_notifier(monkeypatch)
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert len(calls['posted']) == 1
+
+
+def test_notify_posts_no_comment_when_pr_comment_disabled(monkeypatch):
+    notifier, calls = _suppression_notifier(monkeypatch, pr_comment_enabled=False)
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert calls['posted'] == []
+    assert calls['updated'] == []
+
+
+def test_notify_posts_no_all_clear_comment_when_pr_comment_disabled(monkeypatch):
+    """An empty run must not rewrite an existing comment into "no findings"."""
+    existing = """<!-- sast-javascript start -->
+## Socket SAST JavaScript
+
+### Summary
+🟠 High: 1
+<!-- sast-javascript end -->"""
+
+    notifier, calls = _suppression_notifier(monkeypatch, pr_comment_enabled=False)
+    notifier.app_config = {'javascript_sast_enabled': True}
+    monkeypatch.setattr(notifier, '_get_pr_comments', lambda pr_number: [{'id': 99, 'body': existing}])
+
+    notifier.notify({'notifications': [], 'components': []})
+
+    assert calls['posted'] == []
+    assert calls['updated'] == []
+
+
+def test_notify_still_applies_labels_when_pr_comment_disabled(monkeypatch):
+    """Comments and labels are independent switches."""
+    notifier, calls = _suppression_notifier(
+        monkeypatch, pr_comment_enabled=False, pr_labels_enabled=True
+    )
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert calls['labels'] == [['security: critical']]
+
+
+def test_notify_skips_labels_when_both_switches_are_off(monkeypatch):
+    notifier, calls = _suppression_notifier(
+        monkeypatch, pr_comment_enabled=False, pr_labels_enabled=False
+    )
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert calls['posted'] == []
+    assert calls['labels'] == []
+
+
+def test_notify_honors_string_false_from_dashboard_config(monkeypatch):
+    """A Socket dashboard config supplies flags as strings, not booleans."""
+    notifier, calls = _suppression_notifier(monkeypatch, pr_comment_enabled='false')
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert calls['posted'] == []
+
+
+def test_notify_honors_string_false_for_labels(monkeypatch):
+    """pr_labels_enabled needs the same string handling as pr_comment_enabled."""
+    notifier, calls = _suppression_notifier(
+        monkeypatch, pr_comment_enabled='false', pr_labels_enabled='false'
+    )
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert calls['posted'] == []
+    assert calls['labels'] == []
+
+
+def test_notify_string_false_labels_are_skipped_on_the_normal_path(monkeypatch):
+    """Not just the suppression branch -- the ordinary posting path too."""
+    notifier, calls = _suppression_notifier(monkeypatch, pr_labels_enabled='false')
+
+    notifier.notify({'notifications': [_FINDING], 'components': []})
+
+    assert len(calls['posted']) == 1
+    assert calls['labels'] == []
+
+
+def test_notify_leaves_facts_untouched_when_pr_comment_disabled(monkeypatch):
+    """Suppression is comment-only: the uploaded facts payload is not altered."""
+    notifier, _calls = _suppression_notifier(monkeypatch, pr_comment_enabled=False)
+    facts = {
+        'notifications': [_FINDING],
+        'components': [{'id': 'src/index.js', 'alerts': [{'severity': 'critical'}]}],
+        'full_scan_html_url': 'https://socket.dev/dashboard/scan/12345',
+    }
+
+    notifier.notify(facts)
+
+    assert facts['components'] == [{'id': 'src/index.js', 'alerts': [{'severity': 'critical'}]}]
+    assert facts['full_scan_html_url'] == 'https://socket.dev/dashboard/scan/12345'

--- a/tests/test_pr_formatters.py
+++ b/tests/test_pr_formatters.py
@@ -356,3 +356,251 @@ class TestEmptyInputs:
         results = format_notifications([], config=config)
         assert len(results) == 1
         assert "No reachability issues found" in results[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# pr_comment_collapse_all: close the collapsible sections, critical included
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def config_collapse_all():
+    return make_mock_config(collapse_all=True)
+
+
+class TestCollapseAll:
+    """`pr_comment_collapse_all` is the only way to collapse critical findings.
+
+    `pr_comment_collapse_non_critical` deliberately leaves critical sections
+    expanded, so before this flag existed a critical finding always forced the
+    comment open.
+    """
+
+    def test_opengrep_critical_section_is_expanded_by_default(self, config):
+        from socket_basics.core.connector.opengrep.github_pr import format_notifications
+        results = format_notifications(OPENGREP_FIXTURES, config=config)
+        js_content = next(r["content"] for r in results if "JavaScript" in r["title"])
+        assert "<details open>" in js_content
+
+    def test_opengrep_collapses_critical_section_when_enabled(self, config_collapse_all):
+        from socket_basics.core.connector.opengrep.github_pr import format_notifications
+        results = format_notifications(OPENGREP_FIXTURES, config=config_collapse_all)
+        js_content = next(r["content"] for r in results if "JavaScript" in r["title"])
+        assert "<details open>" not in js_content
+        # Sections are still present, just closed.
+        assert "<details>" in js_content
+
+    def test_tier1_critical_section_is_expanded_by_default(self, config):
+        from socket_basics.core.connector.socket_tier1.github_pr import format_notifications
+        content = format_notifications(TIER1_FIXTURES, config=config)[0]["content"]
+        assert "<details open>" in content
+
+    def test_tier1_collapses_critical_section_when_enabled(self, config_collapse_all):
+        from socket_basics.core.connector.socket_tier1.github_pr import format_notifications
+        content = format_notifications(TIER1_FIXTURES, config=config_collapse_all)[0]["content"]
+        assert "<details open>" not in content
+        assert "<details>" in content
+
+
+class TestCollapseAllScope:
+    """The flag only reaches sections that are built from collapsible panels.
+
+    Those are the SAST sections and the Socket Tier 1 section. Secret findings
+    and Dockerfile findings are plain markdown tables, so the flag has nothing
+    to close there, and a closed SAST section still shows one summary row per
+    file. The comment never comes down to a single line, and these tests are
+    what keep the documented contract that narrow.
+    """
+
+    def _trufflehog(self, config):
+        from socket_basics.core.connector.trufflehog.github_pr import format_notifications
+        return format_notifications(TRUFFLEHOG_FIXTURES, config=config)
+
+    def _trivy_dockerfile(self, config):
+        from socket_basics.core.connector.trivy.github_pr import format_notifications
+        return format_notifications(_trivy_dockerfile_fixture(),
+                                    item_name="Dockerfile", scan_type="dockerfile", config=config)
+
+    def _trivy_image(self, config):
+        from socket_basics.core.connector.trivy.github_pr import format_notifications
+        return format_notifications(_trivy_image_fixture(),
+                                    item_name="example-app:latest", scan_type="image", config=config)
+
+    def test_trufflehog_output_is_byte_identical(self, config, config_collapse_all):
+        default = [r["content"] for r in self._trufflehog(config)]
+        collapsed = [r["content"] for r in self._trufflehog(config_collapse_all)]
+        assert collapsed == default
+
+    def test_trufflehog_secrets_stay_fully_visible(self, config_collapse_all):
+        content = self._trufflehog(config_collapse_all)[0]["content"]
+        assert "<details" not in content
+        assert "AWS" in content
+
+    def test_trivy_dockerfile_output_is_byte_identical(self, config, config_collapse_all):
+        default = [r["content"] for r in self._trivy_dockerfile(config)]
+        collapsed = [r["content"] for r in self._trivy_dockerfile(config_collapse_all)]
+        assert collapsed == default
+
+    def test_trivy_dockerfile_findings_stay_fully_visible(self, config_collapse_all):
+        content = self._trivy_dockerfile(config_collapse_all)[0]["content"]
+        assert "<details" not in content
+
+    def test_trivy_image_output_is_byte_identical(self, config, config_collapse_all):
+        default = [r["content"] for r in self._trivy_image(config)]
+        collapsed = [r["content"] for r in self._trivy_image(config_collapse_all)]
+        assert collapsed == default
+
+    def test_sast_keeps_one_visible_summary_row_per_file(self, config_collapse_all):
+        """A closed section is still a row on screen, not nothing."""
+        from socket_basics.core.connector.opengrep.github_pr import format_notifications
+        results = format_notifications(OPENGREP_FIXTURES, config=config_collapse_all)
+        js_content = next(r["content"] for r in results if "JavaScript" in r["title"])
+        assert js_content.count("<summary>") == 2
+        assert "src/server/app.ts" in js_content
+        assert "src/utils/config-loader.js" in js_content
+
+
+class TestFeatureFlagCoercion:
+    """Dashboard-sourced config can deliver flags as strings, not booleans."""
+
+    def test_string_true_enables_collapse_all(self):
+        from socket_basics.core.notification.github_pr_helpers import get_feature_flags
+        flags = get_feature_flags(make_mock_config(collapse_all="true"))
+        assert flags["collapse_all"] is True
+
+    def test_string_false_does_not_enable_collapse_all(self):
+        from socket_basics.core.notification.github_pr_helpers import get_feature_flags
+        flags = get_feature_flags(make_mock_config(collapse_all="false"))
+        assert flags["collapse_all"] is False
+
+    def test_string_false_disables_links(self):
+        from socket_basics.core.notification.github_pr_helpers import get_feature_flags
+        config = make_mock_config()
+        config["pr_comment_links_enabled"] = "false"
+        assert get_feature_flags(config)["enable_links"] is False
+
+    def test_missing_config_keeps_documented_defaults(self):
+        from socket_basics.core.notification.github_pr_helpers import get_feature_flags
+        flags = get_feature_flags(None)
+        assert flags["collapse_all"] is False
+        assert flags["collapse_non_critical"] is True
+
+
+class TestActionInputCoercion:
+    """GitHub Action inputs are always strings, and blank means "unset".
+
+    An input forwarded from an unset workflow variable arrives as an empty
+    string. Reading that as "off" would silently suppress the PR comment for a
+    workflow that never asked to suppress it, so a value that says nothing has
+    to fall back to the documented default.
+    """
+
+    def _load(self, monkeypatch, **env):
+        from socket_basics.core.config import load_config_from_env
+        for name in (
+            "INPUT_PR_COMMENT_ENABLED",
+            "INPUT_PR_COMMENT_COLLAPSE_ALL",
+            "INPUT_PR_LABELS_ENABLED",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        for name, value in env.items():
+            monkeypatch.setenv(name, value)
+        return load_config_from_env()
+
+    def test_comment_stays_enabled_when_the_input_is_unset(self, monkeypatch):
+        assert self._load(monkeypatch).get("pr_comment_enabled") is True
+
+    def test_comment_stays_enabled_for_a_blank_input(self, monkeypatch):
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_ENABLED="")
+        assert config.get("pr_comment_enabled") is True
+
+    def test_comment_stays_enabled_for_a_whitespace_input(self, monkeypatch):
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_ENABLED="   ")
+        assert config.get("pr_comment_enabled") is True
+
+    def test_comment_stays_enabled_for_an_unrecognized_input(self, monkeypatch):
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_ENABLED="maybe")
+        assert config.get("pr_comment_enabled") is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "0", "no", "off"])
+    def test_comment_is_disabled_by_every_false_spelling(self, monkeypatch, value):
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_ENABLED=value)
+        assert config.get("pr_comment_enabled") is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "on"])
+    def test_comment_is_enabled_by_every_true_spelling(self, monkeypatch, value):
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_ENABLED=value)
+        assert config.get("pr_comment_enabled") is True
+
+    def test_collapse_all_stays_off_for_a_blank_input(self, monkeypatch):
+        """A blank input falls back to the default, which here is off."""
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_COLLAPSE_ALL="")
+        assert config.get("pr_comment_collapse_all") is False
+
+    def test_collapse_all_is_enabled_by_a_string_true(self, monkeypatch):
+        config = self._load(monkeypatch, INPUT_PR_COMMENT_COLLAPSE_ALL="true")
+        assert config.get("pr_comment_collapse_all") is True
+
+    def test_labels_stay_enabled_for_a_blank_input(self, monkeypatch):
+        config = self._load(monkeypatch, INPUT_PR_LABELS_ENABLED="")
+        assert config.get("pr_labels_enabled") is True
+
+
+class TestNotifierCliArgsReachTheConfig:
+    """A notifier flag has to survive the whole trip from argv to the config.
+
+    The PR comment flags are declared in notifications.yaml, and the CLI parser
+    registers an option for each one. Parsing that option is only half the job:
+    the value also has to be copied into the effective config, or the scan reads
+    the default and the flag does nothing.
+    """
+
+    def _config(self, monkeypatch, tmp_path, *cli_args, **env):
+        from socket_basics.core.config import parse_cli_args, create_config_from_args
+
+        # A stale INPUT_* variable would decide the outcome instead of the flag.
+        for name in (
+            "INPUT_PR_COMMENT_ENABLED",
+            "INPUT_PR_COMMENT_COLLAPSE_ALL",
+            "INPUT_PR_COMMENT_LINKS_ENABLED",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        for name, value in env.items():
+            monkeypatch.setenv(name, value)
+
+        # tmp_path is not a git repo, so --repo and --branch are required and no
+        # git command can reach the network.
+        argv = ["--workspace", str(tmp_path), "--repo", "acme/widget",
+                "--branch", "feature-x", *cli_args]
+        return create_config_from_args(parse_cli_args().parse_args(argv))
+
+    def test_collapse_all_flag_lands_in_the_effective_config(self, monkeypatch, tmp_path):
+        config = self._config(monkeypatch, tmp_path, "--pr-comment-collapse-all")
+        assert config.get("pr_comment_collapse_all") is True
+
+    def test_collapse_all_stays_off_without_the_flag(self, monkeypatch, tmp_path):
+        config = self._config(monkeypatch, tmp_path)
+        assert config.get("pr_comment_collapse_all") is False
+
+    def test_negative_flag_disables_the_pr_comment(self, monkeypatch, tmp_path):
+        """`pr_comment_enabled` defaults to true, so it needs a `--no-` form."""
+        config = self._config(monkeypatch, tmp_path, "--no-pr-comment")
+        assert config.get("pr_comment_enabled") is False
+
+    def test_positive_flag_keeps_the_pr_comment_enabled(self, monkeypatch, tmp_path):
+        config = self._config(monkeypatch, tmp_path, "--pr-comment")
+        assert config.get("pr_comment_enabled") is True
+
+    def test_pr_comment_stays_enabled_without_any_flag(self, monkeypatch, tmp_path):
+        config = self._config(monkeypatch, tmp_path)
+        assert config.get("pr_comment_enabled") is True
+
+    def test_an_unused_flag_does_not_overwrite_the_environment(self, monkeypatch, tmp_path):
+        """An option nobody passed must read as "unset", not as false.
+
+        The workflow turned links off through the environment. Copying the
+        parser's value for every flag regardless would put that back to on.
+        """
+        config = self._config(monkeypatch, tmp_path, "--pr-comment-collapse-all",
+                              INPUT_PR_COMMENT_LINKS_ENABLED="false")
+        assert config.get("pr_comment_links_enabled") is False
+        assert config.get("pr_comment_collapse_all") is True


### PR DESCRIPTION
Teams can now turn the Socket Basics pull request comment off, or collapse every findings section, without giving up scanning. Findings still reach the Socket dashboard either way. This unblocks teams who want to evaluate finding quality in the dashboard first, without a comment landing on every developer's pull request.

Before this change the comment could not be turned off at all. There was a setting to auto-collapse non-critical findings, but critical findings always stayed expanded, so a single critical finding forced the whole comment open on every push.

## What you get

| Input | Default | What it does |
|-------|---------|--------------|
| `pr_comment_enabled` | `true` | Set to `false` and no comment is posted or updated. |
| `pr_comment_collapse_all` | `false` | Set to `true` and the collapsible findings sections start collapsed. |

**Nothing changes until a workflow opts in.** Both switches default to today's behavior, so existing users see no difference when this merges.

<details>
<summary><b>Why turning off the comment cannot turn off the dashboard</b> - the upload happens before any notifier runs</summary>

`main()` in `socket_basics/socket_basics.py` runs in a fixed order: scanners execute, results are written to `.socket.facts.json`, the facts are uploaded to the Socket dashboard, and only then do the notifiers run.

Because the comment is a notifier, it is the last step. Suppressing it cannot reach backward and suppress the upload that already happened. That ordering is what makes `pr_comment_enabled: false` safe to recommend: you lose the comment, never the data.

</details>

<details>
<summary><b>What collapse-all actually collapses</b> - the SAST and Tier 1 sections, not every formatter</summary>

`pr_comment_collapse_all` is read by the OpenGrep and Tier 1 formatters only. The other outputs are unaffected, for two different reasons:

| Output | Effect | Why |
|--------|--------|-----|
| OpenGrep (SAST) | Collapses | Reads the flag. One summary row per file stays visible. |
| Socket Tier 1 | Collapses | Reads the flag. |
| TruffleHog | No change | Renders a flat table with nothing to collapse. |
| Trivy Dockerfile | No change | Renders a flat table with nothing to collapse. |
| Trivy image and CVE | No change | Already always collapsed, and never reads the flag. |

An earlier draft of this description claimed the comment becomes a single line. That was wrong in three separate ways, and the wording in `action.yml`, the docs, and the README now describes the real behavior. `TestCollapseAllScope` asserts byte-identical output with the flag on and off for the formatters above, so the narrowed contract cannot drift back without a test going red.

</details>

<details>
<summary><b>One fix that came out of review</b> - CLI flags were parsed but never reached the config</summary>

`add_dynamic_cli_args()` registers CLI options from `notifications.yaml`, but `create_config_from_args()` only copied values defined in `connectors.yaml`. Parsing `--pr-comment-collapse-all` produced `True` while the effective config stayed `False`.

Both YAML files describe their parameters in the same shape, so one shared `_apply_param_cli_overrides()` now serves both, which also replaced three inlined copies of the same YAML read.

The subtle part is that every bool option now parses to `None` when absent rather than `False`. Otherwise "the user said nothing" and "the user said false" are the same value, and copying CLI values would clobber environment, JSON, and dashboard config.

Flags that default to true also gained negative forms through `argparse.BooleanOptionalAction`, so `--no-pr-comment` and friends exist. This was applied to every default-true bool parameter rather than just `pr_comment_enabled`, since they all shared the same defect. No connector flag defaults to true, so connector behavior is unchanged.

</details>

## Testing

264 tests pass. Twelve are new: six covering the parser-to-config path and the negative flag forms, and six pinning which formatters collapse-all leaves alone.

Like every change to this action, it reaches users at the next release tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR comment posting and shared config/CLI merging for all notifier bool flags; defaults preserve current behavior, but mis-parsed flags or suppression could surprise teams expecting comments or label behavior.
> 
> **Overview**
> Adds **`pr_comment_enabled`** (default on) so workflows can run scans and Socket dashboard upload without posting or updating the PR findings comment; job failure on high/critical and other notifiers still run, and **`pr_labels_enabled`** stays separate.
> 
> Adds **`pr_comment_collapse_all`** so OpenGrep SAST and Socket Tier 1 `<details>` sections start collapsed even when critical; it overrides **`pr_comment_collapse_non_critical`**. TruffleHog and Dockerfile Trivy output (flat tables) is unchanged.
> 
> Introduces shared **`coerce_bool`** for PR comment flags and env loading so string `"false"`/`"true"`, dashboard strings, and blank or unset `INPUT_*` values resolve consistently (empty → documented default, not silent off).
> 
> Config/CLI: notifier parameters from **`notifications.yaml`** are applied via the same **`_apply_param_cli_overrides`** path as connectors (fixes parsed flags like **`--pr-comment-collapse-all`** never reaching effective config); default-true bools get **`--no-*`** forms; absent CLI options leave env/JSON/dashboard values in place.
> 
> **`action.yml`**, **`notifications.yaml`**, README, and PR comment docs updated; preview script and tests cover suppression, collapse scope, coercion, and CLI wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab96ff8dc1ab14c956b0c389cb7a912f7fcd2492. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->