### PR TITLE
feat(purl): adopt `socketdev` typed batch params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "light-s3-client~=0.0.30",
     "PyYAML>=6.0.0",
     "tomli; python_version < '3.11'",
-    "socketdev>=3.3.0",
+    "socketdev>=3.5.0",
     "jsonschema>=4.25.1"
 ]
 

--- a/scripts/check_core_tools.py
+++ b/scripts/check_core_tools.py
@@ -315,17 +315,18 @@ def analyze_purls(purls: list[str], token: str) -> dict[str, dict[str, Any]]:
     components = [{"purl": p} for p in purls]
     # The batch purl endpoints default to fail-open: inputs whose analysis is
     # pending or unresolvable are silently omitted from the response unless the
-    # caller opts in. Opt in to fail-closed semantics: poll=true waits (bounded
-    # by timeoutSec; the server may cap it) for pending analysis, and
-    # alerts=true materializes still-unresolved inputs as synthetic
-    # pendingScan/notFound rows instead of dropping them. The SDK passes these
-    # extra kwargs through as query params (verified on 3.0.29 and 3.3.0).
+    # caller opts in. Opt in to fail-closed semantics: poll=True waits (bounded
+    # by timeout_sec; the server may cap it) for pending analysis, and
+    # alerts=True materializes still-unresolved inputs as synthetic
+    # pendingScan/notFound rows instead of dropping them. These are first-class
+    # typed params as of socketdev 3.4.2 (previously passed as stringly-typed
+    # query-string kwargs); see CE-360.
     results = client.purl.post(
         license="false",
         components=components,
-        poll="true",
-        timeoutSec="120",
-        alerts="true",
+        poll=True,
+        timeout_sec=120,
+        alerts=True,
         **kwargs,
     ) or []
     if not results:

--- a/uv.lock
+++ b/uv.lock
@@ -702,7 +702,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.33.0" },
-    { name = "socketdev", specifier = ">=3.3.0" },
+    { name = "socketdev", specifier = ">=3.5.0" },
     { name = "tabulate", specifier = "~=0.10.0" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -713,15 +713,15 @@ dev = []
 
 [[package]]
 name = "socketdev"
-version = "3.3.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/30/16155f7f27d18274f364b3bd3506ee45d17f53fc8938aaea9a618054449b/socketdev-3.3.0.tar.gz", hash = "sha256:3d60bd4ac3201e9d581b1fe02bf2e6aef1b90c13ae75d15a8664aa9ef966734e", size = 181519, upload-time = "2026-06-10T11:41:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/0c11290dc7d59e24b7075035c7e1a3ab87fa17a445cebc88cfa6ee98b22c/socketdev-3.5.0.tar.gz", hash = "sha256:a2b20f9b98f73c25f3d2e97a1ae730504509c91219c0b393f28a9230266b3531", size = 195138, upload-time = "2026-08-06T03:47:14.185Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/dd/25622e033182e8c744d2420bb4f056206edc096a1e5ce8e4af4b0a0c0791/socketdev-3.3.0-py3-none-any.whl", hash = "sha256:513c045ce42bdd6cc2bb66a527f5863e0c399e56dbdcb1832cd5d94a5fb1a5e4", size = 67956, upload-time = "2026-06-10T11:41:16.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/75/5a8506a473716740e94f2f01b697909333f966c143d8a0a566d278e6118d/socketdev-3.5.0-py3-none-any.whl", hash = "sha256:780f5841770397035ff87de6181d954b6318cd0a07f6fdd304d1376667f33f68", size = 72027, upload-time = "2026-08-06T03:47:12.773Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

The `core-tool-watch` scoring call in `scripts/check_core_tools.py` opted into the batch purl API's fail-closed semantics via **stringly-typed query-string kwargs** (`poll="true"`, `timeoutSec="120"`, `alerts="true"`) — an undocumented SDK passthrough. `socketdev` (Python SDK) v3.4.2+ promoted these to first-class typed params, so this migrates to the supported surface.

## Changes

- `scripts/check_core_tools.py`: `poll="true"` → `poll=True`, `timeoutSec="120"` → `timeout_sec=120`, `alerts="true"` → `alerts=True`. **Behavior unchanged** (still fail-closed).
- `pyproject.toml`: `socketdev>=3.3.0` → `socketdev>=3.5.0`. Typed params landed in 3.4.2 (on 3.3.0, `timeout_sec` would be sent as a literal `timeout_sec` query param, silently losing the `timeoutSec` fail-closed bound); 3.5.0 additionally bounds the SDK's runtime dependency ranges and hardens PyPI install verification.
- `uv.lock`: regenerated — socketdev `3.3.0` → `3.5.0`.

## Validation (against the published `3.5.0` wheel)

- Full test suite: 216 passed via the CI install path (`uv sync --locked --extra dev`).
- Wire-level check of `analyze_purls` through the real SDK transport: the call produces `POST orgs/<slug>/purl?license=false&poll=true&timeoutSec=120&alerts=true` with the expected components body — typed params map to the exact query params the server expects.
- Synthetic `notFound` rows survive the SDK's dedupe hardening and map to `status=not_found` (fail-closed semantics intact).
- `check_core_tools.py --mode watch` end-to-end run against live GitHub APIs works.

Note: core-tool-watch's scan env installs from main's `uv.lock`, so the typed params take effect there once this merges.

Refs CE-360


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches supply-chain guard scoring for pinned core tools; risk is mitigated by intentional behavior parity and a dependency bump with a documented wire-level mapping requirement.
> 
> **Overview**
> **Core-tool-watch** now uses the **socketdev** SDK’s first-class batch PURL parameters instead of undocumented string query passthroughs. In `analyze_purls`, `poll="true"`, `timeoutSec="120"`, and `alerts="true"` become `poll=True`, `timeout_sec=120`, and `alerts=True` — same fail-closed batch semantics (bounded poll, synthetic `pendingScan`/`notFound` rows).
> 
> The **`socketdev`** floor moves from **`>=3.3.0`** to **`>=3.5.0`** in `pyproject.toml` so typed params (from 3.4.2+) map correctly to API query names like `timeoutSec`; **`uv.lock`** is updated to **3.5.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282050469501c14b9a24c293a2bc619a21ee6f49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->